### PR TITLE
Fix apiresponse method signature mismatch

### DIFF
--- a/src/main/java/com/ocms/common/dto/ApiResponse.java
+++ b/src/main/java/com/ocms/common/dto/ApiResponse.java
@@ -26,4 +26,8 @@ public class ApiResponse<T> {
     public static <T> ApiResponse<T> error(String message) {
         return new ApiResponse<>(false, message, null, LocalDateTime.now());
     }
+
+    public static <T> ApiResponse<T> error(String message, T data) {
+        return new ApiResponse<>(false, message, data, LocalDateTime.now());
+    }
 }


### PR DESCRIPTION
Add overloaded `error` method to `ApiResponse` to support returning error messages with additional data.

This fixes a compilation error in `GlobalExceptionHandler` where `ApiResponse.error` was called with a message and a map of validation errors, but no such method signature existed. The new overload allows for more detailed error responses, particularly for validation failures.

---
<a href="https://cursor.com/background-agent?bcId=bc-24a3b648-d6af-455e-ad41-8ca1d4495adb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-24a3b648-d6af-455e-ad41-8ca1d4495adb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>